### PR TITLE
Update example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The low-level bindings use the typical JavaScript idioms.
 ws, err := websocket.New("ws://localhost/socket") // Does not block.
 if err != nil { handleError() }
 
-onOpen := func(ev js.Object) {
+onOpen := func(ev *js.Object) {
     err := ws.Send([]byte("Hello!")) // Send as a binary frame
     err := ws.Send("Hello!") // Send a text frame
 }


### PR DESCRIPTION
In the example of the low-level bindings, the onOpen requires a pointer to a js.Object.
